### PR TITLE
create_dashboard (cloudwatch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Here's a complete [example](examples/simple/main.tf) of using this `terraform-aw
 |------|-------------|:----:|:-----:|:-----:|
 | add_sns_policy | Attach a policy that allows the notifications through to the SNS topic endpoint | string | `false` | no |
 | additional_endpoint_arns | Any alert endpoints, such as autoscaling, or app scaling endpoint arns that will respond to an alert | list | `<list>` | no |
-| create_dashboard | When true a dashboard that displays tha statistics as a line graph will be created in CloudWatch | string | `true` | no |
+| create_dashboard | When true a dashboard that displays the statistics as a line graph will be created in CloudWatch | string | `true` | no |
 | log_group_name | The cloudtrail cloudwatch log group name | string | - | yes |
 | metric_namespace | A namespace for grouping all of the metrics together | string | `CISBenchmark` | no |
 | region | The region that should be monitored for unauthorised AWS API Access. Current region used if none provied. | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,11 +1,10 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | add_sns_policy | Attach a policy that allows the notifications through to the SNS topic endpoint | string | `false` | no |
 | additional_endpoint_arns | Any alert endpoints, such as autoscaling, or app scaling endpoint arns that will respond to an alert | list | `<list>` | no |
-| create_dashboard | When true a dashboard that displays tha statistics as a line graph will be created in CloudWatch | string | `true` | no |
+| create_dashboard | When true a dashboard that displays the statistics as a line graph will be created in CloudWatch | string | `true` | no |
 | log_group_name | The cloudtrail cloudwatch log group name | string | - | yes |
 | metric_namespace | A namespace for grouping all of the metrics together | string | `CISBenchmark` | no |
 | region | The region that should be monitored for unauthorised AWS API Access. Current region used if none provied. | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -53,8 +53,14 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     resources = ["${local.sns_topic_arn}"]
 
     principals {
-      type        = "Service"
-      identifiers = ["events.amazonaws.com"]
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = ["${aws_cloudwatch_metric_alarm.default.*.arn}"]
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,6 @@ variable "metric_namespace" {
 }
 
 variable "create_dashboard" {
-  description = "When true a dashboard that displays tha statistics as a line graph will be created in CloudWatch"
+  description = "When true a dashboard that displays the statistics as a line graph will be created in CloudWatch"
   default     = "true"
 }


### PR DESCRIPTION
-  create_dashboard | When true a dashboard that displays the statistics as a line graph will be created in CloudWatch | string | `true` | no |